### PR TITLE
[Feat] 검색화면의 코드 구조를 MVVM + Clean 아키텍처로 변경하였습니다.

### DIFF
--- a/CaloLink.xcodeproj/project.pbxproj
+++ b/CaloLink.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		BC1650772DBCB5D40026A0FC /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1650762DBCB5D40026A0FC /* MainView.swift */; };
 		BC1650792DBCB5DF0026A0FC /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1650782DBCB5DF0026A0FC /* MainViewController.swift */; };
 		BC16507B2DBCB84A0026A0FC /* CategoryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC16507A2DBCB84A0026A0FC /* CategoryButton.swift */; };
+		BC3B41432DCA11D2000A2E15 /* DIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3B41422DCA11D2000A2E15 /* DIContainer.swift */; };
 		BC5FC1612DC5E8D4009A36B6 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5FC1602DC5E8D4009A36B6 /* SearchViewController.swift */; };
 		BC5FC1642DC5FE7B009A36B6 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5FC1632DC5FE7B009A36B6 /* ListViewController.swift */; };
 		BC5FC1692DC63204009A36B6 /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5FC1682DC63204009A36B6 /* ListTableViewCell.swift */; };
@@ -42,6 +43,7 @@
 		BC1650762DBCB5D40026A0FC /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		BC1650782DBCB5DF0026A0FC /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		BC16507A2DBCB84A0026A0FC /* CategoryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButton.swift; sourceTree = "<group>"; };
+		BC3B41422DCA11D2000A2E15 /* DIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIContainer.swift; sourceTree = "<group>"; };
 		BC5FC1602DC5E8D4009A36B6 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		BC5FC1632DC5FE7B009A36B6 /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
 		BC5FC1682DC63204009A36B6 /* ListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 				BCAEF9462DAA443300BB355E /* AppDelegate.swift */,
 				BCAEF94A2DAA443300BB355E /* SceneDelegate.swift */,
 				BCAEF94B2DAA443300BB355E /* ViewController.swift */,
+				BC3B41422DCA11D2000A2E15 /* DIContainer.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -407,6 +410,7 @@
 				BCAEF95D2DAA468F00BB355E /* APIConstant.swift in Sources */,
 				BC5FC1612DC5E8D4009A36B6 /* SearchViewController.swift in Sources */,
 				BCAEF96A2DAA4A8400BB355E /* Endpoint.swift in Sources */,
+				BC3B41432DCA11D2000A2E15 /* DIContainer.swift in Sources */,
 				BCAEF9682DAA4A7900BB355E /* Requestable.swift in Sources */,
 				BCAEF94D2DAA443300BB355E /* AppDelegate.swift in Sources */,
 				BCAEF94E2DAA443300BB355E /* SceneDelegate.swift in Sources */,

--- a/CaloLink.xcodeproj/project.pbxproj
+++ b/CaloLink.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		BC1650792DBCB5DF0026A0FC /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1650782DBCB5DF0026A0FC /* MainViewController.swift */; };
 		BC16507B2DBCB84A0026A0FC /* CategoryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC16507A2DBCB84A0026A0FC /* CategoryButton.swift */; };
 		BC3B41432DCA11D2000A2E15 /* DIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3B41422DCA11D2000A2E15 /* DIContainer.swift */; };
+		BC3B41472DCA2EC9000A2E15 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3B41462DCA2EC9000A2E15 /* SearchViewModel.swift */; };
+		BC3B414C2DCA2F5E000A2E15 /* SearchKeywordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3B414B2DCA2F5E000A2E15 /* SearchKeywordRepository.swift */; };
+		BC3B41512DCA318B000A2E15 /* SearchKeywordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3B41502DCA318B000A2E15 /* SearchKeywordUseCase.swift */; };
 		BC5FC1612DC5E8D4009A36B6 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5FC1602DC5E8D4009A36B6 /* SearchViewController.swift */; };
 		BC5FC1642DC5FE7B009A36B6 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5FC1632DC5FE7B009A36B6 /* ListViewController.swift */; };
 		BC5FC1692DC63204009A36B6 /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5FC1682DC63204009A36B6 /* ListTableViewCell.swift */; };
@@ -44,6 +47,9 @@
 		BC1650782DBCB5DF0026A0FC /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		BC16507A2DBCB84A0026A0FC /* CategoryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButton.swift; sourceTree = "<group>"; };
 		BC3B41422DCA11D2000A2E15 /* DIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIContainer.swift; sourceTree = "<group>"; };
+		BC3B41462DCA2EC9000A2E15 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
+		BC3B414B2DCA2F5E000A2E15 /* SearchKeywordRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKeywordRepository.swift; sourceTree = "<group>"; };
+		BC3B41502DCA318B000A2E15 /* SearchKeywordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKeywordUseCase.swift; sourceTree = "<group>"; };
 		BC5FC1602DC5E8D4009A36B6 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		BC5FC1632DC5FE7B009A36B6 /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
 		BC5FC1682DC63204009A36B6 /* ListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
@@ -117,6 +123,46 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		BC3B41452DCA2EB9000A2E15 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				BC3B41462DCA2EC9000A2E15 /* SearchViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		BC3B41492DCA2F31000A2E15 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				BC3B414A2DCA2F50000A2E15 /* Search */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
+		BC3B414A2DCA2F50000A2E15 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				BC3B414B2DCA2F5E000A2E15 /* SearchKeywordRepository.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		BC3B414E2DCA317A000A2E15 /* UseCase */ = {
+			isa = PBXGroup;
+			children = (
+				BC3B414F2DCA3180000A2E15 /* Search */,
+			);
+			path = UseCase;
+			sourceTree = "<group>";
+		};
+		BC3B414F2DCA3180000A2E15 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				BC3B41502DCA318B000A2E15 /* SearchKeywordUseCase.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
 		BC5C0BD02DAAAE5B008A5F18 /* CaloLink */ = {
 			isa = PBXGroup;
 			children = (
@@ -130,6 +176,7 @@
 			isa = PBXGroup;
 			children = (
 				BC5FC15A2DC5E85E009A36B6 /* View */,
+				BC3B41452DCA2EB9000A2E15 /* ViewModel */,
 			);
 			path = SearchScene;
 			sourceTree = "<group>";
@@ -225,6 +272,7 @@
 			isa = PBXGroup;
 			children = (
 				BCAEF95A2DAA452100BB355E /* Network */,
+				BC3B41492DCA2F31000A2E15 /* Repository */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -232,6 +280,7 @@
 		BCAEF9582DAA44EA00BB355E /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				BC3B414E2DCA317A000A2E15 /* UseCase */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -407,9 +456,11 @@
 				BCAEF96F2DAA51AA00BB355E /* ServerError.swift in Sources */,
 				BC1650772DBCB5D40026A0FC /* MainView.swift in Sources */,
 				BC5FC1772DC6FFCB009A36B6 /* SearchKeywordTableViewCell.swift in Sources */,
+				BC3B414C2DCA2F5E000A2E15 /* SearchKeywordRepository.swift in Sources */,
 				BCAEF95D2DAA468F00BB355E /* APIConstant.swift in Sources */,
 				BC5FC1612DC5E8D4009A36B6 /* SearchViewController.swift in Sources */,
 				BCAEF96A2DAA4A8400BB355E /* Endpoint.swift in Sources */,
+				BC3B41512DCA318B000A2E15 /* SearchKeywordUseCase.swift in Sources */,
 				BC3B41432DCA11D2000A2E15 /* DIContainer.swift in Sources */,
 				BCAEF9682DAA4A7900BB355E /* Requestable.swift in Sources */,
 				BCAEF94D2DAA443300BB355E /* AppDelegate.swift in Sources */,
@@ -428,6 +479,7 @@
 				BC5FC1642DC5FE7B009A36B6 /* ListViewController.swift in Sources */,
 				BCAEF9612DAA479B00BB355E /* HttpMethod.swift in Sources */,
 				BC5FC16D2DC64138009A36B6 /* ListNoProductView.swift in Sources */,
+				BC3B41472DCA2EC9000A2E15 /* SearchViewModel.swift in Sources */,
 				BCAEF9732DAA5D0E00BB355E /* NetworkManagerProtocol.swift in Sources */,
 				BCAEF95F2DAA475100BB355E /* NetworkError.swift in Sources */,
 			);

--- a/CaloLink/Source/Application/AppDelegate.swift
+++ b/CaloLink/Source/Application/AppDelegate.swift
@@ -28,10 +28,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         )
 
         // MARK: - Repository
+        diContainer.register(
+            SearchKeywordRepository.self,
+            instance: SearchKeywordRepository()
+        )
 
         // MARK: - UseCase
+        diContainer.register(
+            SearchKeywordUseCase.self,
+            instance: SearchKeywordUseCase(
+                searchKeywordRepository: diContainer.resolve(SearchKeywordRepositoryProtocol.self)
+            )
+        )
 
         // MARK: - ViewModel
+        diContainer.register(
+            SearchViewModel.self,
+            instance: SearchViewModel(
+                searchKeywordUseCase: diContainer.resolve(SearchKeywordUseCaseProtocol.self)
+            )
+        )
     }
 
     // MARK: UISceneSession Lifecycle

--- a/CaloLink/Source/Application/AppDelegate.swift
+++ b/CaloLink/Source/Application/AppDelegate.swift
@@ -13,8 +13,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        // Override point for customization after application launch.
+        registerDependencies()
         return true
+    }
+
+    // MARK: - Register Dependencies
+    private func registerDependencies() {
+        let diContainer = DIContainer.shared
+
+        // MARK: - NetworkManager
+        diContainer.register(
+            NetworkManagerProtocol.self,
+            instance: NetworkManager()
+        )
+
+        // MARK: - Repository
+
+        // MARK: - UseCase
+
+        // MARK: - ViewModel
     }
 
     // MARK: UISceneSession Lifecycle

--- a/CaloLink/Source/Application/AppDelegate.swift
+++ b/CaloLink/Source/Application/AppDelegate.swift
@@ -29,13 +29,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // MARK: - Repository
         diContainer.register(
-            SearchKeywordRepository.self,
+            SearchKeywordRepositoryProtocol.self,
             instance: SearchKeywordRepository()
         )
 
         // MARK: - UseCase
         diContainer.register(
-            SearchKeywordUseCase.self,
+            SearchKeywordUseCaseProtocol.self,
             instance: SearchKeywordUseCase(
                 searchKeywordRepository: diContainer.resolve(SearchKeywordRepositoryProtocol.self)
             )
@@ -43,7 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // MARK: - ViewModel
         diContainer.register(
-            SearchViewModel.self,
+            SearchViewModelProtocol.self,
             instance: SearchViewModel(
                 searchKeywordUseCase: diContainer.resolve(SearchKeywordUseCaseProtocol.self)
             )

--- a/CaloLink/Source/Application/DIContainer.swift
+++ b/CaloLink/Source/Application/DIContainer.swift
@@ -1,0 +1,30 @@
+//
+//  DIContainer.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 5/6/25.
+//
+
+import Foundation
+
+final class DIContainer {
+    static let shared = DIContainer()
+    private var dependencies: [String: Any] = [:]
+
+    private init() {}
+
+    // MARK: - Register
+    func register<T>(_ type: T.Type, instance: T) {
+        let key = String(describing: type)
+        dependencies[key] = instance
+    }
+
+    // MARK: - Resolve
+    func resolve<T>(_ type: T.Type) -> T {
+        let key = String(describing: type)
+        guard let instance = dependencies[key] as? T else {
+            fatalError("\(key) 의존성이 등록되지 않았습니다.")
+        }
+        return instance
+    }
+}

--- a/CaloLink/Source/Data/Repository/Search/SearchKeywordRepository.swift
+++ b/CaloLink/Source/Data/Repository/Search/SearchKeywordRepository.swift
@@ -1,0 +1,45 @@
+//
+//  SearchKeywordRepository.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 5/6/25.
+//
+
+import Foundation
+
+protocol SearchKeywordRepositoryProtocol {
+    func fetchKeywords() -> [String]
+    func saveKeyword(_ keyword: String)
+    func allDeleteKeywords()
+    func deleteKeyword(_ keyword: String)
+}
+
+final class SearchKeywordRepository: SearchKeywordRepositoryProtocol {
+    private let key = "recentSearchKeywords"
+
+    func fetchKeywords() -> [String] {
+        return UserDefaults.standard.stringArray(forKey: key) ?? []
+    }
+
+    func saveKeyword(_ keyword: String) {
+        var keywords = fetchKeywords()
+        keywords.removeAll() { $0 == keyword }
+        keywords.insert(keyword, at: 0)
+
+        if keyword.count > 10 {
+            keywords = Array(keywords.prefix(10))
+        }
+
+        UserDefaults.standard.set(keywords, forKey: key)
+    }
+
+    func allDeleteKeywords() {
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    func deleteKeyword(_ keyword: String) {
+        var keywords = fetchKeywords()
+        keywords.removeAll { $0 == keyword }
+        UserDefaults.standard.set(keywords, forKey: key)
+    }
+}

--- a/CaloLink/Source/Domain/UseCase/Search/SearchKeywordUseCase.swift
+++ b/CaloLink/Source/Domain/UseCase/Search/SearchKeywordUseCase.swift
@@ -1,0 +1,39 @@
+//
+//  SearchKeywordUseCase.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 5/6/25.
+//
+
+import Foundation
+
+protocol SearchKeywordUseCaseProtocol {
+    func fetchKeywords() -> [String]
+    func saveKeyword(_ keyword: String)
+    func allDeleteKeywords()
+    func deleteKeyword(_ keyword: String)
+}
+
+final class SearchKeywordUseCase: SearchKeywordUseCaseProtocol {
+    private let searchKeywordRepository: SearchKeywordRepositoryProtocol
+
+    init(searchKeywordRepository: SearchKeywordRepositoryProtocol) {
+        self.searchKeywordRepository = searchKeywordRepository
+    }
+
+    func fetchKeywords() -> [String] {
+        return searchKeywordRepository.fetchKeywords()
+    }
+
+    func saveKeyword(_ keyword: String) {
+        searchKeywordRepository.saveKeyword(keyword)
+    }
+
+    func allDeleteKeywords() {
+        searchKeywordRepository.allDeleteKeywords()
+    }
+
+    func deleteKeyword(_ keyword: String) {
+        searchKeywordRepository.deleteKeyword(keyword)
+    }
+}

--- a/CaloLink/Source/Presentation/ListScene/View/ListViewController.swift
+++ b/CaloLink/Source/Presentation/ListScene/View/ListViewController.swift
@@ -12,6 +12,8 @@ class ListViewController: UIViewController {
     private let listNoProductView = ListNoProductView()
     var searchText: String?
 
+    private let searchViewModel: SearchViewModelProtocol
+
     private let searchTextField: UITextField = {
         let textField = UITextField()
         textField.layer.borderColor = UIColor.systemGray4.cgColor
@@ -39,6 +41,20 @@ class ListViewController: UIViewController {
         return textField
     }()
 
+    // MARK: - Init
+    init(
+        searchText: String? = nil,
+        searchViewModel: SearchViewModelProtocol
+    ) {
+        self.searchText = searchText
+        self.searchViewModel = searchViewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func loadView() {
         view = listView
     }
@@ -50,15 +66,15 @@ class ListViewController: UIViewController {
         configureTableView()
         configureAddTarget()
     }
-}
 
-// MARK: - Configure TextField
-extension ListViewController: UITextFieldDelegate {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         searchTextField.text = searchText
     }
+}
 
+// MARK: - Configure TextField
+extension ListViewController: UITextFieldDelegate {
     private func configureTextField() {
         searchTextField.delegate = self
     }
@@ -73,10 +89,9 @@ extension ListViewController: UITextFieldDelegate {
             return false
         }
 
-        addRecentKeyword(keyword)
+        searchViewModel.addKeyword(keyword)
 
-        let newListViewController = ListViewController()
-        newListViewController.searchText = keyword
+        let newListViewController = ListViewController(searchText: keyword, searchViewModel: searchViewModel)
         navigationController?.pushViewController(newListViewController, animated: true)
 
         return true
@@ -160,28 +175,13 @@ extension ListViewController: UITableViewDataSource {
 // MARK: - 셀 선택 처리
 extension ListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-            guard let cell = tableView.cellForRow(at: indexPath) as? ListTableViewCell else { return }
+        guard let cell = tableView.cellForRow(at: indexPath) as? ListTableViewCell else { return }
 
-            let detailVC = DetailViewController()
-            detailVC.productImage = cell.getImage()
-            detailVC.productName = cell.getTitle()
+        let detailVC = DetailViewController()
+        detailVC.productImage = cell.getImage()
+        detailVC.productName = cell.getTitle()
 
-            navigationController?.pushViewController(detailVC, animated: true)
-        }
-}
-
-// MARK: - 최근 검색어 저장
-extension ListViewController {
-    private func addRecentKeyword(_ keyword: String) {
-        var keywords = UserDefaults.standard.stringArray(forKey: "recentSearchKeywords") ?? []
-        keywords.removeAll { $0 == keyword }
-        keywords.insert(keyword, at: 0)
-
-        if keywords.count > 10 {
-            keywords = Array(keywords.prefix(10))
-        }
-
-        UserDefaults.standard.set(keywords, forKey: "recentSearchKeywords")
+        navigationController?.pushViewController(detailVC, animated: true)
     }
 }
 

--- a/CaloLink/Source/Presentation/MainScene/View/MainViewController.swift
+++ b/CaloLink/Source/Presentation/MainScene/View/MainViewController.swift
@@ -29,7 +29,8 @@ extension MainViewController {
     }
 
     private func searchButtonTapped() {
-        let searchViewController = SearchViewController()
+        let searchViewModel = DIContainer.shared.resolve(SearchViewModelProtocol.self)
+        let searchViewController = SearchViewController(searchViewModel: searchViewModel)
         navigationController?.pushViewController(searchViewController, animated: true)
     }
 }

--- a/CaloLink/Source/Presentation/SearchScene/View/SearchViewController.swift
+++ b/CaloLink/Source/Presentation/SearchScene/View/SearchViewController.swift
@@ -136,7 +136,7 @@ extension SearchViewController: UITextFieldDelegate {
 
         searchViewModel.addKeyword(keyword)
 
-        let listViewController = ListViewController()
+        let listViewController = ListViewController(searchViewModel: searchViewModel)
         listViewController.searchText = keyword
         navigationController?.pushViewController(listViewController, animated: true)
 

--- a/CaloLink/Source/Presentation/SearchScene/View/SearchViewController.swift
+++ b/CaloLink/Source/Presentation/SearchScene/View/SearchViewController.swift
@@ -8,8 +8,9 @@
 import UIKit
 
 class SearchViewController: UIViewController {
+    // MARK: - Properties
     private let searchView = SearchView()
-    private var recentKeywords: [String] = []
+    private var searchViewModel: SearchViewModelProtocol
 
     private let searchTextField: UITextField = {
         let textField = UITextField()
@@ -38,28 +39,45 @@ class SearchViewController: UIViewController {
         return textField
     }()
 
-    // MARK: - Life Cycle
+    // MARK: - Initializer
+    init(searchViewModel: SearchViewModelProtocol) {
+        self.searchViewModel = searchViewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func loadView() {
         view = searchView
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureBinding()
+        configureInitialKeywords()
         configureNavigationBar()
         configureTextField()
         configureTableView()
         configureAddTarget()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        loadRecentKeywords()
-        searchView.searchKeywordTableView.reloadData()
-    }
-
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         searchTextField.becomeFirstResponder()
+    }
+}
+// MARK: - Bind func
+extension SearchViewController {
+    private func configureBinding() {
+        searchViewModel.keywordsUpdatedHandler = { [weak self] in
+            self?.searchView.searchKeywordTableView.reloadData()
+        }
+    }
+
+    private func configureInitialKeywords() {
+        searchViewModel.loadKeywords()
     }
 }
 
@@ -110,14 +128,13 @@ extension SearchViewController: UITextFieldDelegate {
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        guard let keyword = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines), !keyword.isEmpty else {
-            return false
-        }
+        guard let keyword = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !keyword.isEmpty else { return false }
 
         textField.resignFirstResponder()
         textField.text = ""
 
-        addRecentKeyword(keyword)
+        searchViewModel.addKeyword(keyword)
 
         let listViewController = ListViewController()
         listViewController.searchText = keyword
@@ -128,19 +145,16 @@ extension SearchViewController: UITextFieldDelegate {
 }
 
 // MARK: - Configure TableView
-extension SearchViewController {
+extension SearchViewController: UITableViewDataSource, UITableViewDelegate {
     private func configureTableView() {
         let tableView = searchView.searchKeywordTableView
         tableView.delegate = self
         tableView.dataSource = self
         tableView.register(SearchKeywordTableViewCell.self, forCellReuseIdentifier: "SearchKeywordTableViewCell")
     }
-}
 
-// MARK: - UITableViewDataSource, UITableViewDelegate
-extension SearchViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return recentKeywords.count
+        return searchViewModel.keywords.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -150,72 +164,36 @@ extension SearchViewController: UITableViewDataSource, UITableViewDelegate {
         ) as? SearchKeywordTableViewCell else {
             return UITableViewCell()
         }
-        let keyword = recentKeywords[indexPath.row]
+
+        let keyword = searchViewModel.keywords[indexPath.row]
         cell.configureKeyword(with: keyword)
         cell.delegate = self
         return cell
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let keyword = recentKeywords[indexPath.row]
+        let keyword = searchViewModel.keywords[indexPath.row]
         searchTextField.text = keyword
         _ = textFieldShouldReturn(searchTextField)
     }
 }
 
-// MARK: - 최근 검색어 처리
-extension SearchViewController {
-    private func addRecentKeyword(_ keyword: String) {
-        var keywords = UserDefaults.standard.stringArray(forKey: "recentSearchKeywords") ?? []
-        keywords.removeAll { $0 == keyword }
-        keywords.insert(keyword, at: 0)
-
-        if keywords.count > 10 {
-            keywords = Array(keywords.prefix(10))
-        }
-
-        UserDefaults.standard.set(keywords, forKey: "recentSearchKeywords")
-        recentKeywords = keywords
-        searchView.searchKeywordTableView.reloadData()
-    }
-
-    private func clearRecentKeywords() {
-        recentKeywords = []
-        UserDefaults.standard.removeObject(forKey: "recentSearchKeywords")
-        searchView.searchKeywordTableView.reloadData()
-    }
-
-    private func loadRecentKeywords() {
-        recentKeywords = UserDefaults.standard.stringArray(forKey: "recentSearchKeywords") ?? []
-    }
-}
-
-// MARK: - 셀 삭제 버튼 델리게이트 처리
+// MARK: - 셀 개별 삭제 델리게이트
 extension SearchViewController: SearchKeywordTableViewCellDelegate {
     func deleteButtonTapped(in cell: SearchKeywordTableViewCell) {
         guard let indexPath = searchView.searchKeywordTableView.indexPath(for: cell) else { return }
-
-        let keywordToDelete = recentKeywords[indexPath.row]
-        var keywords = UserDefaults.standard.stringArray(forKey: "recentSearchKeywords") ?? []
-        keywords.removeAll { $0 == keywordToDelete }
-
-        if keywords.count > 10 {
-            keywords = Array(keywords.prefix(10))
-        }
-
-        UserDefaults.standard.set(keywords, forKey: "recentSearchKeywords")
-        recentKeywords = keywords
-        searchView.searchKeywordTableView.reloadData()
+        let keyword = searchViewModel.keywords[indexPath.row]
+        searchViewModel.deleteKeyword(keyword)
     }
 }
 
-// MARK: - Configure addTarget: 전체삭제 버튼
+// MARK: - Configure AddTarget
 extension SearchViewController {
     private func configureAddTarget() {
-        searchView.allDeleteButton.addTarget(self, action: #selector(clearAllKeywords), for: .touchUpInside)
+        searchView.allDeleteButton.addTarget(self, action: #selector(allDeleteButtonTapped), for: .touchUpInside)
     }
 
-    @objc private func clearAllKeywords() {
-        clearRecentKeywords()
+    @objc private func allDeleteButtonTapped() {
+        searchViewModel.allDeleteKeywords()
     }
 }

--- a/CaloLink/Source/Presentation/SearchScene/ViewModel/SearchViewModel.swift
+++ b/CaloLink/Source/Presentation/SearchScene/ViewModel/SearchViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  SearchViewModel.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 5/6/25.
+//
+
+import Foundation
+
+protocol SearchViewModelProtocol {
+    var keywords: [String] { get }
+    var keywordsUpdatedHandler: (() -> Void)? { get set }
+
+    func loadKeywords()
+    func addKeyword(_ keyword: String)
+    func allDeleteKeywords()
+    func deleteKeyword(_ keyword: String)
+}
+
+final class SearchViewModel: SearchViewModelProtocol {
+    private let searchKeywordUseCase: SearchKeywordUseCaseProtocol
+
+    var keywords: [String] = [] {
+        didSet {
+            keywordsUpdatedHandler?()
+        }
+    }
+
+    var keywordsUpdatedHandler: (() -> Void)?
+
+    init(searchKeywordUseCase: SearchKeywordUseCaseProtocol) {
+        self.searchKeywordUseCase = searchKeywordUseCase
+    }
+
+    func loadKeywords() {
+        keywords = searchKeywordUseCase.fetchKeywords()
+    }
+
+    func addKeyword(_ keyword: String) {
+        searchKeywordUseCase.saveKeyword(keyword)
+        loadKeywords()
+    }
+
+    func allDeleteKeywords() {
+        searchKeywordUseCase.allDeleteKeywords()
+        loadKeywords()
+    }
+
+    func deleteKeyword(_ keyword: String) {
+        searchKeywordUseCase.deleteKeyword(keyword)
+        loadKeywords()
+    }
+}


### PR DESCRIPTION
# 배경
#25 
검색화면의 UI만 구성하였던 기존 코드에서 MVVM + Clean 아키텍처에 맞게 코드를 수정하였습니다.
또한, DIContainer의 도입으로 의존성 관리를 효율적으로 할 수 있게 하였습니다.

# 작업 내용
- DIContainer: DIContainer파일에서 개념을 정의해두고, 앱델에서 등록하는 코드를 작성하였습니다.
- SearchKeyword의 레포지토리, 유즈케이스, 뷰모델, 뷰컨 순서로 코드를 작성하였습니다.
- ListVC에서도 검색을 할 수 있으므로 SearchViewModel을 사용하여 처리하였습니다.

# 테스트 방법
- 시뮬레이터를 통해 확인할 수 있습니다.

# 리뷰 노트
- DIContainer와 MVVM + Clean 아키텍처의 개념은 따로 정리하여 기록하겠습니다.
